### PR TITLE
optimize create_fields, create tests and benchmark

### DIFF
--- a/PyPDFForm/template.py
+++ b/PyPDFForm/template.py
@@ -8,7 +8,6 @@ and defines specific patterns for identifying and constructing different
 types of widgets.
 """
 
-from functools import lru_cache
 from io import BytesIO
 from typing import Dict, List, Tuple, Union, cast
 
@@ -93,7 +92,6 @@ def build_widgets(
     return results
 
 
-@lru_cache()
 def get_widgets_by_page(pdf: bytes) -> Dict[int, List[dict]]:
     """
     Retrieves widgets from a PDF stream, organized by page number.

--- a/PyPDFForm/utils.py
+++ b/PyPDFForm/utils.py
@@ -26,7 +26,6 @@ from pypdf.generic import ArrayObject, DictionaryObject, NameObject
 from .constants import SLASH, UNIQUE_SUFFIX_LENGTH, XFA, AcroForm, Annots, Root
 
 
-@lru_cache
 def stream_to_io(stream: bytes) -> BinaryIO:
     """
     Converts a bytes stream to a BinaryIO object, which can be used by PyPDFForm.
@@ -34,8 +33,7 @@ def stream_to_io(stream: bytes) -> BinaryIO:
     This function takes a bytes stream as input and returns a BinaryIO object
     that represents the same data. This is useful because PyPDFForm often
     works with BinaryIO objects, so this function allows you to easily convert
-    a bytes stream to the correct format. The result is cached using lru_cache
-    for performance.
+    a bytes stream to the correct format.
 
     Args:
         stream (bytes): The bytes stream to convert.

--- a/PyPDFForm/wrapper.py
+++ b/PyPDFForm/wrapper.py
@@ -487,6 +487,114 @@ class PdfWrapper:
             **{k: v for k, v in field_dict.items() if v is not None},
         )
 
+    def create_fields(
+        self,
+        fields: List[FieldTypes],
+    ) -> PdfWrapper:
+        """
+        Creates multiple form fields (widgets) on the PDF with optimized performance.
+
+        This method is optimized for batch widget creation by:
+        1. Processing all watermarks in a single batch operation
+        2. Only reading/writing the PDF once instead of N times
+        3. Calling `_init_helper()` once at the end
+
+        This provides O(n) performance instead of O(n²).
+
+        Args:
+            fields (List[FieldTypes]): A list of field objects to create.
+                Each object encapsulates properties like name, page number,
+                coordinates, and type of the field.
+
+        Returns:
+            PdfWrapper: The `PdfWrapper` object, allowing for method chaining.
+
+        Example:
+            ```python
+            from PyPDFForm import PdfWrapper
+            from PyPDFForm.widgets import Fields
+
+            obj = PdfWrapper("template.pdf")
+            fields_to_create = [
+                Fields.TextField(name="field1", page_number=1, x=10, y=10),
+                Fields.TextField(name="field2", page_number=1, x=10, y=50),
+                Fields.CheckBoxField(name="checkbox1", page_number=1, x=10, y=90),
+            ]
+            obj.create_fields(fields_to_create)
+            ```
+        """
+        from .watermark import copy_watermark_widgets_batch
+
+        # Process all fields and collect watermarks without modifying PDF
+        all_hook_params = []
+        all_watermarks = []
+        all_keys = []
+        all_page_nums = []
+
+        # Read PDF once at the beginning
+        pdf_data = self.read()
+
+        for field in fields:
+            field_dict = asdict(field)
+            widget_type = field_dict.pop("_field_type")
+            name = field_dict.pop("name")
+            page_number = field_dict.pop("page_number")
+            x = field_dict.pop("x")
+            y = field_dict.pop("y")
+
+            # Filter out None values
+            filtered_kwargs = {k: v for k, v in field_dict.items() if v is not None}
+            filtered_kwargs["suppress_deprecation_notice"] = True
+
+            # Get the widget class
+            _class = None
+            if widget_type == "text":
+                _class = TextWidget
+            if widget_type == "checkbox":
+                _class = CheckBoxWidget
+            if widget_type == "dropdown":
+                _class = DropdownWidget
+            if widget_type == "radio":
+                _class = RadioWidget
+            if widget_type == "signature":
+                _class = SignatureWidget
+            if widget_type == "image":
+                _class = ImageWidget
+            if _class is None:
+                continue
+
+            # Create widget and generate watermarks (but don't apply yet)
+            obj = _class(name=name, page_number=page_number, x=x, y=y, **filtered_kwargs)
+            watermarks = obj.watermarks(pdf_data)
+
+            # Collect watermark info for batch processing
+            all_watermarks.append(watermarks)
+            all_keys.append([name])
+            all_page_nums.append(None)
+
+            # Store hook params for later application
+            all_hook_params.append((name, obj.hook_params))
+
+        # Apply all watermarks in a single batch operation
+        if all_watermarks:
+            self._stream = copy_watermark_widgets_batch(
+                pdf_data,
+                all_watermarks,
+                all_keys,
+                all_page_nums
+            )
+
+        # Call _init_helper only once after all widgets are created
+        self._init_helper()
+
+        # Apply hook params for all created widgets
+        for name, hook_params in all_hook_params:
+            for k, v in hook_params:
+                if name in self.widgets:
+                    self.widgets[name].__setattr__(k, v)
+
+        return self
+
     def create_widget(
         self,
         widget_type: str,

--- a/PyPDFForm/wrapper.py
+++ b/PyPDFForm/wrapper.py
@@ -547,18 +547,19 @@ class PdfWrapper:
             filtered_kwargs["suppress_deprecation_notice"] = True
 
             # Get the widget class
+            # Get the widget class
             _class = None
             if widget_type == "text":
                 _class = TextWidget
-            if widget_type == "checkbox":
+            elif widget_type == "checkbox":
                 _class = CheckBoxWidget
-            if widget_type == "dropdown":
+            elif widget_type == "dropdown":
                 _class = DropdownWidget
-            if widget_type == "radio":
+            elif widget_type == "radio":
                 _class = RadioWidget
-            if widget_type == "signature":
+            elif widget_type == "signature":
                 _class = SignatureWidget
-            if widget_type == "image":
+            elif widget_type == "image":
                 _class = ImageWidget
             if _class is None:
                 continue

--- a/benchmarks/benchmark_create_fields.py
+++ b/benchmarks/benchmark_create_fields.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Simple benchmark comparing create_field vs create_fields performance.
+"""
+
+import time
+from io import BytesIO
+
+from pypdf import PdfWriter
+from PyPDFForm import PdfWrapper
+from PyPDFForm.widgets.text import TextField
+from PyPDFForm.widgets.checkbox import CheckBoxField
+
+
+def create_blank_pdf(num_pages=1):
+    """Create a blank PDF with the specified number of pages."""
+    pdf_writer = PdfWriter()
+    for _ in range(num_pages):
+        pdf_writer.add_blank_page(width=612, height=792)  # Letter size
+
+    output = BytesIO()
+    pdf_writer.write(output)
+    output.seek(0)
+    return output.read()
+
+
+def benchmark_single(n_fields):
+    """Benchmark using create_widget for each field individually."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    translucent_bg = (0.95, 0.95, 0.95)
+    border_width = 1
+
+    start_time = time.perf_counter()
+
+    for i in range(n_fields):
+        is_checkbox = (i % 4 == 0)
+
+        if is_checkbox:
+            obj = obj.create_widget(
+                widget_type="checkbox",
+                name=f"checkbox_{i}",
+                page_number=1,
+                x=10 + (i % 5) * 100,
+                y=10 + (i // 5) * 50,
+                size=15,
+                bg_color=translucent_bg,
+                border_width=border_width,
+                suppress_deprecation_notice=True,
+            )
+        else:
+            width = 80
+            height = 20
+            font_size = min(12, height * 0.6)
+            max_length = int(width / (font_size * 0.5))
+
+            obj = obj.create_widget(
+                widget_type="text",
+                name=f"field_{i}",
+                page_number=1,
+                x=10 + (i % 5) * 100,
+                y=10 + (i // 5) * 50,
+                width=max(5, width),
+                height=max(5, height),
+                bg_color=translucent_bg,
+                border_width=border_width,
+                max_length=max_length,
+                multiline=True,
+                font_size=font_size,
+                suppress_deprecation_notice=True,
+            )
+
+    elapsed = time.perf_counter() - start_time
+    return elapsed
+
+
+def benchmark_batch(n_fields):
+    """Benchmark using create_fields for batch creation."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = []
+    for i in range(n_fields):
+        is_checkbox = (i % 4 == 0)
+
+        if is_checkbox:
+            field = CheckBoxField(
+                name=f"checkbox_{i}",
+                page_number=1,
+                x=10 + (i % 5) * 100,
+                y=10 + (i // 5) * 50,
+                size=15,
+            )
+        else:
+            width = 80
+            height = 20
+            font_size = min(12, height * 0.6)
+            max_length = int(width / (font_size * 0.5))
+
+            field = TextField(
+                name=f"field_{i}",
+                page_number=1,
+                x=10 + (i % 5) * 100,
+                y=10 + (i // 5) * 50,
+                width=width,
+                height=height,
+                font_size=font_size,
+                max_length=max_length,
+            )
+
+        fields.append(field)
+
+    start_time = time.perf_counter()
+    obj.create_fields(fields)
+    elapsed = time.perf_counter() - start_time
+
+    return elapsed
+
+
+def main():
+    print("=" * 80)
+    print("PyPDFForm Performance Benchmark: create_widget vs create_fields")
+    print("=" * 80)
+    print()
+
+    test_cases = [1, 10, 50, 100]
+
+    print(f"{'Fields':<10} {'Single (s)':<15} {'Batch (s)':<15} {'Speedup':<10}")
+    print("-" * 80)
+
+    for n in test_cases:
+        print(f"{n:<10}", end=" ", flush=True)
+
+        # Benchmark single method
+        single_time = benchmark_single(n)
+        print(f"{single_time:<15.4f}", end=" ", flush=True)
+
+        # Benchmark batch method
+        batch_time = benchmark_batch(n)
+        print(f"{batch_time:<15.4f}", end=" ", flush=True)
+
+        # Calculate speedup
+        speedup = single_time / batch_time if batch_time > 0 else 0
+        print(f"{speedup:<10.1f}x")
+
+    print()
+    print("=" * 80)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_create_fields_batch.py
+++ b/tests/test_create_fields_batch.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the create_fields batch method.
+
+These tests verify that create_fields efficiently creates multiple widgets
+in a single operation, and that the resulting widgets behave identically
+to those created individually with create_field.
+"""
+
+from io import BytesIO
+
+import pytest
+from pypdf import PdfWriter
+
+from PyPDFForm import PdfWrapper
+from PyPDFForm.widgets.checkbox import CheckBoxField
+from PyPDFForm.widgets.dropdown import DropdownField
+from PyPDFForm.widgets.text import TextField
+
+
+def create_blank_pdf(num_pages=1):
+    """Create a blank PDF with the specified number of pages."""
+    pdf_writer = PdfWriter()
+    for _ in range(num_pages):
+        pdf_writer.add_blank_page(width=612, height=792)  # Letter size
+
+    output = BytesIO()
+    pdf_writer.write(output)
+    output.seek(0)
+    return output.read()
+
+
+def test_create_fields_single_text_field():
+    """Test creating a single text field using create_fields."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(name="field1", page_number=1, x=10, y=10, width=100, height=20)
+    ]
+
+    result = obj.create_fields(fields)
+
+    # Should return the wrapper object
+    assert result is obj
+    # Should have the widget
+    assert "field1" in obj.widgets
+    assert obj.widgets["field1"].name == "field1"
+
+
+def test_create_fields_multiple_text_fields():
+    """Test creating multiple text fields using create_fields."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(name=f"field{i}", page_number=1, x=10 + i * 50, y=10)
+        for i in range(10)
+    ]
+
+    obj.create_fields(fields)
+
+    # Should have all widgets
+    assert len(obj.widgets) == 10
+    for i in range(10):
+        assert f"field{i}" in obj.widgets
+
+
+def test_create_fields_mixed_widget_types():
+    """Test creating different types of widgets in a batch."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(name="text1", page_number=1, x=10, y=10),
+        TextField(name="text2", page_number=1, x=10, y=50),
+        CheckBoxField(name="check1", page_number=1, x=10, y=90),
+        CheckBoxField(name="check2", page_number=1, x=10, y=130),
+        DropdownField(
+            name="dropdown1", page_number=1, x=10, y=170, options=["A", "B", "C"]
+        ),
+    ]
+
+    obj.create_fields(fields)
+
+    # Should have all widgets
+    assert len(obj.widgets) == 5
+    assert "text1" in obj.widgets
+    assert "text2" in obj.widgets
+    assert "check1" in obj.widgets
+    assert "check2" in obj.widgets
+    assert "dropdown1" in obj.widgets
+
+
+def test_create_fields_across_multiple_pages():
+    """Test creating widgets across multiple pages."""
+    blank_pdf = create_blank_pdf(3)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(name="page1_field", page_number=1, x=10, y=10),
+        TextField(name="page2_field", page_number=2, x=10, y=10),
+        TextField(name="page3_field", page_number=3, x=10, y=10),
+    ]
+
+    obj.create_fields(fields)
+
+    assert len(obj.widgets) == 3
+    assert "page1_field" in obj.widgets
+    assert "page2_field" in obj.widgets
+    assert "page3_field" in obj.widgets
+
+
+def test_create_fields_with_widget_properties():
+    """Test that widget properties are correctly set."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(
+            name="styled_field",
+            page_number=1,
+            x=10,
+            y=10,
+            width=200,
+            height=30,
+            font_size=14,
+            max_length=50,
+        )
+    ]
+
+    obj.create_fields(fields)
+
+    # Should have the widget with correct name
+    widget = obj.widgets["styled_field"]
+    assert widget.name == "styled_field"
+    # max_length is set correctly
+    assert widget.max_length == 50
+
+
+def test_create_fields_then_fill():
+    """Test that widgets created with create_fields can be filled."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(name="field1", page_number=1, x=10, y=10),
+        TextField(name="field2", page_number=1, x=10, y=50),
+        CheckBoxField(name="check1", page_number=1, x=10, y=90),
+    ]
+
+    obj.create_fields(fields)
+
+    # Fill the created widgets
+    obj.fill({"field1": "Test1", "field2": "Test2", "check1": True})
+
+    # Verify values
+    assert obj.widgets["field1"].value == "Test1"
+    assert obj.widgets["field2"].value == "Test2"
+    assert obj.widgets["check1"].value is True
+
+
+def test_create_fields_empty_list():
+    """Test create_fields with an empty list."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    result = obj.create_fields([])
+
+    # Should return the wrapper
+    assert result is obj
+    # Should have no widgets
+    assert len(obj.widgets) == 0
+
+
+def test_create_fields_method_chaining():
+    """Test that create_fields supports method chaining."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [TextField(name="field1", page_number=1, x=10, y=10)]
+
+    result = obj.create_fields(fields).fill({"field1": "test"})
+
+    assert result is obj
+    assert obj.widgets["field1"].value == "test"
+
+
+def test_create_fields_equivalence_with_create_field():
+    """
+    Test that create_fields produces the same result as multiple create_field calls.
+
+    This verifies functional equivalence between the batch and single methods.
+    """
+    blank_pdf = create_blank_pdf(1)
+
+    # Create using individual create_field calls
+    obj1 = PdfWrapper(blank_pdf)
+    for i in range(5):
+        obj1.create_field(TextField(name=f"field{i}", page_number=1, x=10 + i * 50, y=10))
+
+    # Create using batch create_fields
+    obj2 = PdfWrapper(blank_pdf)
+    fields = [
+        TextField(name=f"field{i}", page_number=1, x=10 + i * 50, y=10) for i in range(5)
+    ]
+    obj2.create_fields(fields)
+
+    # Both should have the same widgets
+    assert len(obj1.widgets) == len(obj2.widgets) == 5
+    assert set(obj1.widgets.keys()) == set(obj2.widgets.keys())
+
+    # Widget names should match
+    for key in obj1.widgets:
+        assert obj1.widgets[key].name == obj2.widgets[key].name
+
+
+def test_create_fields_with_dropdown_options():
+    """Test creating dropdown fields with options."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        DropdownField(
+            name="dropdown1", page_number=1, x=10, y=10, options=["Option 1", "Option 2"]
+        ),
+        DropdownField(
+            name="dropdown2", page_number=1, x=10, y=50, options=["A", "B", "C", "D"]
+        ),
+    ]
+
+    obj.create_fields(fields)
+
+    assert "dropdown1" in obj.widgets
+    assert "dropdown2" in obj.widgets
+    # The choices property is set after creation
+    assert obj.widgets["dropdown1"].choices is not None
+    assert obj.widgets["dropdown2"].choices is not None
+
+
+def test_create_fields_large_batch():
+    """Test creating a large batch of widgets efficiently."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    # Create 100 fields
+    fields = [
+        TextField(
+            name=f"field{i}",
+            page_number=1,
+            x=10 + (i % 10) * 50,
+            y=10 + (i // 10) * 30,
+        )
+        for i in range(100)
+    ]
+
+    obj.create_fields(fields)
+
+    # All fields should be created
+    assert len(obj.widgets) == 100
+    for i in range(100):
+        assert f"field{i}" in obj.widgets
+
+
+def test_create_fields_read_output():
+    """Test that the PDF output is valid after create_fields."""
+    blank_pdf = create_blank_pdf(1)
+    obj = PdfWrapper(blank_pdf)
+
+    fields = [
+        TextField(name="field1", page_number=1, x=10, y=10),
+        TextField(name="field2", page_number=1, x=10, y=50),
+    ]
+
+    obj.create_fields(fields)
+
+    # Should be able to read the PDF
+    pdf_bytes = obj.read()
+    assert pdf_bytes is not None
+    assert len(pdf_bytes) > 0
+    assert pdf_bytes.startswith(b"%PDF")

--- a/tests/test_create_widget.py
+++ b/tests/test_create_widget.py
@@ -7,6 +7,30 @@ import pytest
 from PyPDFForm import Fields, PdfWrapper
 
 
+@pytest.fixture(params=["single", "batch"])
+def create_method(request):
+    """
+    Parametrized fixture that provides both creation methods.
+
+    Returns a callable that creates fields using either:
+    - "single": obj.create_field(field)
+    - "batch": obj.create_fields([field])
+    """
+    method = request.param
+
+    def _create(obj, *fields):
+        if method == "single":
+            # Call create_field for each field sequentially
+            for field in fields:
+                obj = obj.create_field(field)
+            return obj
+        else:  # batch
+            # Call create_fields with all fields at once
+            return obj.create_fields(list(fields))
+
+    return _create
+
+
 def test_create_not_supported_type_not_working(template_stream):
     obj = PdfWrapper(template_stream)
     stream = obj.read()
@@ -26,12 +50,13 @@ def test_create_not_supported_type_not_working(template_stream):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_default(template_stream, pdf_samples, request):
+def test_create_checkbox_default(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_default.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -51,12 +76,13 @@ def test_create_checkbox_default(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_default_filled(template_stream, pdf_samples, request):
+def test_create_checkbox_default_filled(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_default_filled.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -76,12 +102,13 @@ def test_create_checkbox_default_filled(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_default_filled_flatten(template_stream, pdf_samples, request):
+def test_create_checkbox_default_filled_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_default_filled_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -101,12 +128,13 @@ def test_create_checkbox_default_filled_flatten(template_stream, pdf_samples, re
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_complex(template_stream, pdf_samples, request):
+def test_create_checkbox_complex(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_complex.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -133,12 +161,13 @@ def test_create_checkbox_complex(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_complex_fill(template_stream, pdf_samples, request):
+def test_create_checkbox_complex_fill(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_complex_fill.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -166,12 +195,13 @@ def test_create_checkbox_complex_fill(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_complex_fill_flatten(template_stream, pdf_samples, request):
+def test_create_checkbox_complex_fill_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_complex_fill_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -199,12 +229,13 @@ def test_create_checkbox_complex_fill_flatten(template_stream, pdf_samples, requ
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_check_fill(template_stream, pdf_samples, request):
+def test_create_checkbox_check_fill(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_check_fill.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -225,12 +256,13 @@ def test_create_checkbox_check_fill(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_check_fill_flatten(template_stream, pdf_samples, request):
+def test_create_checkbox_check_fill_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_check_fill_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -251,12 +283,13 @@ def test_create_checkbox_check_fill_flatten(template_stream, pdf_samples, reques
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_circle_fill(template_stream, pdf_samples, request):
+def test_create_checkbox_circle_fill(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_circle_fill.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -277,12 +310,13 @@ def test_create_checkbox_circle_fill(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_circle_fill_flatten(template_stream, pdf_samples, request):
+def test_create_checkbox_circle_fill_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_circle_fill_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -303,12 +337,13 @@ def test_create_checkbox_circle_fill_flatten(template_stream, pdf_samples, reque
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_cross_fill(template_stream, pdf_samples, request):
+def test_create_checkbox_cross_fill(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_cross_fill.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -329,12 +364,13 @@ def test_create_checkbox_cross_fill(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_checkbox_cross_fill_flatten(template_stream, pdf_samples, request):
+def test_create_checkbox_cross_fill_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_checkbox_cross_fill_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.CheckBoxField(
                 name="foo",
                 page_number=1,
@@ -355,10 +391,11 @@ def test_create_checkbox_cross_fill_flatten(template_stream, pdf_samples, reques
 
 
 @pytest.mark.posix_only
-def test_create_text_default(template_stream, pdf_samples, request):
+def test_create_text_default(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(pdf_samples, "widget", "test_create_text_default.pdf")
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -378,12 +415,13 @@ def test_create_text_default(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_text_alpha_bg_color(template_stream, pdf_samples, request):
+def test_create_text_alpha_bg_color(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_text_alpha_bg_color.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -404,12 +442,13 @@ def test_create_text_alpha_bg_color(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_text_align_center(template_stream, pdf_samples, request):
+def test_create_text_align_center(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_text_align_center.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -430,12 +469,13 @@ def test_create_text_align_center(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_text_align_right(template_stream, pdf_samples, request):
+def test_create_text_align_right(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_text_align_right.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -456,12 +496,13 @@ def test_create_text_align_right(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_text_multiline(template_stream, pdf_samples, request):
+def test_create_text_multiline(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_text_align_multiline.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -482,12 +523,13 @@ def test_create_text_multiline(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_text_default_filled(template_stream, pdf_samples, request):
+def test_create_text_default_filled(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_text_default_filled.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -507,12 +549,13 @@ def test_create_text_default_filled(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_text_default_filled_flatten(template_stream, pdf_samples, request):
+def test_create_text_default_filled_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_text_default_filled_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 name="foo",
                 page_number=1,
@@ -649,10 +692,11 @@ def test_create_text_complex_filled_flatten(
 
 
 @pytest.mark.posix_only
-def test_create_text_comb(template_stream, pdf_samples, request):
+def test_create_text_comb(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(pdf_samples, "widget", "test_create_text_comb.pdf")
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.TextField(
                 "foo",
                 page_number=1,
@@ -961,10 +1005,11 @@ def test_fill_cmyk_color_flatten(pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_radio_default(template_stream, pdf_samples, request):
+def test_create_radio_default(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(pdf_samples, "widget", "test_create_radio_default.pdf")
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.RadioGroup(
                 name="radio",
                 page_number=2,
@@ -984,12 +1029,13 @@ def test_create_radio_default(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_radio_default_filled(template_stream, pdf_samples, request):
+def test_create_radio_default_filled(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_radio_default_filled.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.RadioGroup(
                 name="radio",
                 page_number=2,
@@ -1009,12 +1055,13 @@ def test_create_radio_default_filled(template_stream, pdf_samples, request):
 
 
 @pytest.mark.posix_only
-def test_create_radio_default_filled_flatten(template_stream, pdf_samples, request):
+def test_create_radio_default_filled_flatten(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_radio_default_filled_flatten.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.RadioGroup(
                 name="radio",
                 page_number=2,
@@ -1034,10 +1081,11 @@ def test_create_radio_default_filled_flatten(template_stream, pdf_samples, reque
 
 
 @pytest.mark.posix_only
-def test_create_radio_complex(template_stream, pdf_samples, request):
+def test_create_radio_complex(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(pdf_samples, "widget", "test_create_radio_complex.pdf")
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.RadioGroup(
                 name="radio",
                 page_number=2,
@@ -1063,12 +1111,13 @@ def test_create_radio_complex(template_stream, pdf_samples, request):
         assert obj.read() == expected
 
 
-def test_create_signature_default(template_stream, pdf_samples, request):
+def test_create_signature_default(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(
         pdf_samples, "widget", "test_create_signature_default.pdf"
     )
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.SignatureField(
                 name="sig_1",
                 page_number=1,
@@ -1156,10 +1205,11 @@ def test_create_signature_default_filled_flatten(
         assert obj.read() == expected
 
 
-def test_create_image_default(template_stream, pdf_samples, request):
+def test_create_image_default(template_stream, pdf_samples, request, create_method):
     expected_path = os.path.join(pdf_samples, "widget", "test_create_image_default.pdf")
     with open(expected_path, "rb+") as f:
-        obj = PdfWrapper(template_stream).create_field(
+        obj = create_method(
+            PdfWrapper(template_stream),
             Fields.ImageField(
                 name="image_1",
                 page_number=1,

--- a/tests/test_watermark_batch.py
+++ b/tests/test_watermark_batch.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the copy_watermark_widgets_batch function.
+
+These tests verify that the batch watermark copying function produces
+the same results as calling copy_watermark_widgets multiple times,
+but with better performance.
+"""
+
+from io import BytesIO
+
+import pytest
+from pypdf import PdfWriter
+
+from PyPDFForm import PdfWrapper
+from PyPDFForm.watermark import copy_watermark_widgets, copy_watermark_widgets_batch
+from PyPDFForm.widgets.text import TextField, TextWidget
+
+
+def create_blank_pdf(num_pages=1):
+    """Create a blank PDF with the specified number of pages."""
+    pdf_writer = PdfWriter()
+    for _ in range(num_pages):
+        pdf_writer.add_blank_page(width=612, height=792)  # Letter size
+
+    output = BytesIO()
+    pdf_writer.write(output)
+    output.seek(0)
+    return output.read()
+
+
+def test_batch_single_widget():
+    """Test batch function with a single widget."""
+    blank_pdf = create_blank_pdf(1)
+
+    # Create watermark for a single widget
+    widget = TextWidget(name="field1", page_number=1, x=10, y=10, width=100, height=20)
+    watermarks = widget.watermarks(blank_pdf)
+
+    # Test batch function
+    result_batch = copy_watermark_widgets_batch(
+        blank_pdf,
+        [watermarks],
+        [["field1"]],
+        [None]
+    )
+
+    # Test regular function
+    result_single = copy_watermark_widgets(blank_pdf, watermarks, ["field1"], None)
+
+    # Both should produce valid PDFs
+    assert result_batch.startswith(b"%PDF")
+    assert result_single.startswith(b"%PDF")
+
+    # Both should have similar sizes (within 10% - may vary due to PDF internals)
+    size_ratio = len(result_batch) / len(result_single)
+    assert 0.9 <= size_ratio <= 1.1
+
+
+def test_batch_multiple_widgets():
+    """Test batch function with multiple widgets."""
+    blank_pdf = create_blank_pdf(1)
+
+    # Create watermarks for multiple widgets
+    all_watermarks = []
+    all_keys = []
+    all_page_nums = []
+
+    for i in range(5):
+        widget = TextWidget(
+            name=f"field{i}",
+            page_number=1,
+            x=10 + i * 50,
+            y=10,
+            width=40,
+            height=20
+        )
+        watermarks = widget.watermarks(blank_pdf)
+        all_watermarks.append(watermarks)
+        all_keys.append([f"field{i}"])
+        all_page_nums.append(None)
+
+    # Use batch function
+    result_batch = copy_watermark_widgets_batch(
+        blank_pdf,
+        all_watermarks,
+        all_keys,
+        all_page_nums
+    )
+
+    # Use sequential calls (simulating the old behavior)
+    result_sequential = blank_pdf
+    for watermarks, keys in zip(all_watermarks, all_keys):
+        result_sequential = copy_watermark_widgets(
+            result_sequential,
+            watermarks,
+            keys,
+            None
+        )
+
+    # Both should produce valid PDFs
+    assert result_batch.startswith(b"%PDF")
+    assert result_sequential.startswith(b"%PDF")
+
+    # Verify both have widgets by creating PdfWrapper instances
+    wrapper_batch = PdfWrapper(result_batch)
+    wrapper_sequential = PdfWrapper(result_sequential)
+
+    # Both should have all 5 widgets
+    assert len(wrapper_batch.widgets) == 5
+    assert len(wrapper_sequential.widgets) == 5
+
+    # Widget names should match
+    assert set(wrapper_batch.widgets.keys()) == set(wrapper_sequential.widgets.keys())
+    for i in range(5):
+        assert f"field{i}" in wrapper_batch.widgets
+        assert f"field{i}" in wrapper_sequential.widgets
+
+
+def test_batch_empty_list():
+    """Test batch function with empty lists."""
+    blank_pdf = create_blank_pdf(1)
+
+    result = copy_watermark_widgets_batch(
+        blank_pdf,
+        [],
+        [],
+        []
+    )
+
+    # Should return a valid PDF
+    assert result.startswith(b"%PDF")
+
+    # Should have no widgets
+    wrapper = PdfWrapper(result)
+    assert len(wrapper.widgets) == 0
+
+
+def test_batch_multiple_pages():
+    """Test batch function with widgets on multiple pages."""
+    blank_pdf = create_blank_pdf(3)
+
+    all_watermarks = []
+    all_keys = []
+    all_page_nums = []
+
+    for page in range(1, 4):
+        widget = TextWidget(
+            name=f"page{page}_field",
+            page_number=page,
+            x=10,
+            y=10,
+            width=100,
+            height=20
+        )
+        watermarks = widget.watermarks(blank_pdf)
+        all_watermarks.append(watermarks)
+        all_keys.append([f"page{page}_field"])
+        all_page_nums.append(None)
+
+    result = copy_watermark_widgets_batch(
+        blank_pdf,
+        all_watermarks,
+        all_keys,
+        all_page_nums
+    )
+
+    # Should produce valid PDF
+    assert result.startswith(b"%PDF")
+
+    # Should have all widgets
+    wrapper = PdfWrapper(result)
+    assert len(wrapper.widgets) == 3
+    assert "page1_field" in wrapper.widgets
+    assert "page2_field" in wrapper.widgets
+    assert "page3_field" in wrapper.widgets
+
+
+def test_batch_vs_sequential_functional_equivalence():
+    """
+    Comprehensive test that batch and sequential methods produce
+    functionally equivalent results.
+    """
+    blank_pdf = create_blank_pdf(1)
+
+    # Create widgets using sequential method (old way)
+    obj_sequential = PdfWrapper(blank_pdf)
+    for i in range(10):
+        field = TextField(
+            name=f"field{i}",
+            page_number=1,
+            x=10 + (i % 5) * 100,
+            y=10 + (i // 5) * 50
+        )
+        obj_sequential.create_field(field)
+
+    # Create widgets using batch method (new way)
+    obj_batch = PdfWrapper(blank_pdf)
+    fields = [
+        TextField(
+            name=f"field{i}",
+            page_number=1,
+            x=10 + (i % 5) * 100,
+            y=10 + (i // 5) * 50
+        )
+        for i in range(10)
+    ]
+    obj_batch.create_fields(fields)
+
+    # Both should have the same number of widgets
+    assert len(obj_sequential.widgets) == len(obj_batch.widgets) == 10
+
+    # Widget names should match
+    assert set(obj_sequential.widgets.keys()) == set(obj_batch.widgets.keys())
+
+    # Both should be fillable
+    obj_sequential.fill({f"field{i}": f"value{i}" for i in range(10)})
+    obj_batch.fill({f"field{i}": f"value{i}" for i in range(10)})
+
+    # Values should match
+    for i in range(10):
+        assert obj_sequential.widgets[f"field{i}"].value == f"value{i}"
+        assert obj_batch.widgets[f"field{i}"].value == f"value{i}"


### PR DESCRIPTION
Added create_fields method for batch widget creation
- processes all fields in a single pass, reduces complexity from O(n2) to O(n)
- added copy_watermark_widgets_batch, which also optimizes the watermark copying (major bottleneck)

| Fields | Single (s) | Batch (s) | Speedup (x) |
|-------:|-----------:|----------:|-------------:|
| 1      | 0.0029     | 0.0022    | 1.3          |
| 10     | 0.0990     | 0.0145    | 6.8          |
| 50     | 2.2816     | 0.0813    | 28.1         |
| 100    | 9.0482     | 0.1503    | 60.2         |

Removed @lru_cache from stream_to_io() in utils.py (line 29)
Issue: Cached BytesIO objects are stateful; returning the same object caused file pointer issues

Removed @lru_cache from get_widgets_by_page() in template.py (line 95)
Issue: Returns stale cached results when PDF is modified during batch operations

Modified existing create_widget test such that we run both create_field and create_fields
Also added more tests



