### PR TITLE
add defensive checks for nonetypes

### DIFF
--- a/PyPDFForm/__init__.py
+++ b/PyPDFForm/__init__.py
@@ -20,7 +20,7 @@ The library supports various PDF form features, including:
 PyPDFForm aims to simplify PDF form manipulation, making it accessible to developers of all skill levels.
 """
 
-__version__ = "3.8.2"
+__version__ = "3.8.2.1"
 
 from .assets.blank import BlankPage
 from .middleware import Widgets

--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -113,8 +113,11 @@ def fill(
     for page_num, page in enumerate(out.pages):
         images_to_draw[page_num + 1] = []
         for annot in page.get(Annots, []):
-            annot = cast(DictionaryObject, annot.get_object())
-            key = get_widget_key(annot.get_object(), use_full_widget_name)
+            annot_obj = annot.get_object()
+            if annot_obj is None:
+                continue
+            annot = cast(DictionaryObject, annot_obj)
+            key = get_widget_key(annot_obj, use_full_widget_name)
 
             widget = widgets.get(key)
             if widget is None:

--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -10,6 +10,7 @@ supports flattening the filled form to prevent further modifications.
 
 from io import BytesIO
 from typing import Dict, Union, cast
+from warnings import warn
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.generic import DictionaryObject
@@ -115,6 +116,12 @@ def fill(
         for annot in page.get(Annots, []):
             annot_obj = annot.get_object()
             if annot_obj is None:
+                warn(
+                    f"Skipping annotation on page {page_num + 1}: "
+                    "annotation object is None (possibly corrupted PDF).",
+                    UserWarning,
+                    stacklevel=2,
+                )
                 continue
             annot = cast(DictionaryObject, annot_obj)
             key = get_widget_key(annot_obj, use_full_widget_name)

--- a/PyPDFForm/hooks.py
+++ b/PyPDFForm/hooks.py
@@ -12,6 +12,7 @@ filling process, allowing for customization of the form's appearance and behavio
 import sys
 from io import BytesIO
 from typing import cast
+from warnings import warn
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.generic import (ArrayObject, DictionaryObject, FloatObject,
@@ -53,10 +54,16 @@ def trigger_widget_hooks(
     output = PdfWriter()
     output.append(pdf_file)
 
-    for page in output.pages:
+    for page_num, page in enumerate(output.pages):
         for annot in page.get(Annots, []):
             annot_obj = annot.get_object()
             if annot_obj is None:
+                warn(
+                    f"Skipping annotation on page {page_num + 1}: "
+                    "annotation object is None (possibly corrupted PDF).",
+                    UserWarning,
+                    stacklevel=2,
+                )
                 continue
             annot = cast(DictionaryObject, annot_obj)
             key = get_widget_key(annot_obj, use_full_widget_name)

--- a/PyPDFForm/hooks.py
+++ b/PyPDFForm/hooks.py
@@ -55,8 +55,11 @@ def trigger_widget_hooks(
 
     for page in output.pages:
         for annot in page.get(Annots, []):
-            annot = cast(DictionaryObject, annot.get_object())
-            key = get_widget_key(annot.get_object(), use_full_widget_name)
+            annot_obj = annot.get_object()
+            if annot_obj is None:
+                continue
+            annot = cast(DictionaryObject, annot_obj)
+            key = get_widget_key(annot_obj, use_full_widget_name)
 
             widget = widgets.get(key)
             if widget is None or not widget.hooks_to_trigger:

--- a/PyPDFForm/template.py
+++ b/PyPDFForm/template.py
@@ -297,10 +297,16 @@ def update_widget_keys(
         index = indices[i]
         new_key = new_keys[i]
         tracker = -1
-        for page in out.pages:
+        for page_num, page in enumerate(out.pages):
             for annot in page.get(Annots, []):
                 annot_obj = annot.get_object()
                 if annot_obj is None:
+                    warn(
+                        f"Skipping annotation on page {page_num + 1}: "
+                        "annotation object is None (possibly corrupted PDF).",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     continue
                 annot = cast(DictionaryObject, annot_obj)
                 key = get_widget_key(annot_obj, False)

--- a/PyPDFForm/template.py
+++ b/PyPDFForm/template.py
@@ -299,8 +299,11 @@ def update_widget_keys(
         tracker = -1
         for page in out.pages:
             for annot in page.get(Annots, []):
-                annot = cast(DictionaryObject, annot.get_object())
-                key = get_widget_key(annot.get_object(), False)
+                annot_obj = annot.get_object()
+                if annot_obj is None:
+                    continue
+                annot = cast(DictionaryObject, annot_obj)
+                key = get_widget_key(annot_obj, False)
 
                 widget = widgets.get(key)
                 if widget is None:

--- a/PyPDFForm/watermark.py
+++ b/PyPDFForm/watermark.py
@@ -255,7 +255,10 @@ def copy_watermark_widgets(
         for j, page in enumerate(watermark_file.pages):
             widgets_to_copy_pdf[j] = []
             for annot in page.get(Annots, []):
-                key = get_widget_key(annot.get_object(), False)
+                annot_obj = annot.get_object()
+                if annot_obj is None:
+                    continue
+                key = get_widget_key(annot_obj, False)
 
                 # cannot be watermarks when page_num not None
                 if (keys is None or key in keys) and (

--- a/PyPDFForm/watermark.py
+++ b/PyPDFForm/watermark.py
@@ -11,6 +11,7 @@ and to copy specific widgets from the watermarks to the original PDF.
 from collections import defaultdict
 from io import BytesIO
 from typing import List, Union
+from warnings import warn
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.generic import ArrayObject, NameObject
@@ -257,6 +258,12 @@ def copy_watermark_widgets(
             for annot in page.get(Annots, []):
                 annot_obj = annot.get_object()
                 if annot_obj is None:
+                    warn(
+                        f"Skipping annotation on page {j + 1}: "
+                        "annotation object is None (possibly corrupted PDF).",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     continue
                 key = get_widget_key(annot_obj, False)
 

--- a/PyPDFForm/widgets/signature.py
+++ b/PyPDFForm/widgets/signature.py
@@ -113,13 +113,16 @@ class SignatureWidget:
 
         for page in out.pages:
             for annot in page.get(Annots, []):
-                key = get_widget_key(annot.get_object(), False)
+                annot_obj = annot.get_object()
+                if annot_obj is None:
+                    continue
+                key = get_widget_key(annot_obj, False)
 
                 if key != self.BEDROCK_WIDGET_TO_COPY:
                     continue
 
-                annot.get_object()[NameObject(T)] = TextStringObject(self.name)
-                annot.get_object()[NameObject(Rect)] = ArrayObject(
+                annot_obj[NameObject(T)] = TextStringObject(self.name)
+                annot_obj[NameObject(Rect)] = ArrayObject(
                     [
                         FloatObject(self.x),
                         FloatObject(self.y),
@@ -167,8 +170,11 @@ class SignatureWidget:
         page = bedrock.pages[0]
         annot_type_to_annot = {}
         for annot in page.get(Annots, []):  # pylint: disable=E1101
-            key = get_widget_key(annot.get_object(), False)
-            annot_type_to_annot[key] = annot.get_object()
+            annot_obj = annot.get_object()
+            if annot_obj is None:
+                continue
+            key = get_widget_key(annot_obj, False)
+            annot_type_to_annot[key] = annot_obj
 
         watermark = BytesIO()
 

--- a/PyPDFForm/widgets/signature.py
+++ b/PyPDFForm/widgets/signature.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from io import BytesIO
 from typing import List, Optional, Type
+from warnings import warn
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.generic import (ArrayObject, FloatObject, NameObject,
@@ -111,10 +112,16 @@ class SignatureWidget:
         out = PdfWriter()
         out.append(pdf)
 
-        for page in out.pages:
+        for page_num, page in enumerate(out.pages):
             for annot in page.get(Annots, []):
                 annot_obj = annot.get_object()
                 if annot_obj is None:
+                    warn(
+                        f"Skipping annotation on page {page_num + 1}: "
+                        "annotation object is None (possibly corrupted PDF).",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     continue
                 key = get_widget_key(annot_obj, False)
 
@@ -172,6 +179,12 @@ class SignatureWidget:
         for annot in page.get(Annots, []):  # pylint: disable=E1101
             annot_obj = annot.get_object()
             if annot_obj is None:
+                warn(
+                    "Skipping annotation on page 1: "
+                    "annotation object is None (possibly corrupted PDF).",
+                    UserWarning,
+                    stacklevel=2,
+                )
                 continue
             key = get_widget_key(annot_obj, False)
             annot_type_to_annot[key] = annot_obj

--- a/PyPDFForm/wrapper.py
+++ b/PyPDFForm/wrapper.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 from dataclasses import asdict
 from functools import cached_property
 from typing import TYPE_CHECKING, BinaryIO, Dict, List, Tuple, Union
+from warnings import warn
 
 from .adapter import fp_or_f_obj_or_stream_to_stream
 from .ap import appearance_streams_handler

--- a/tests/test_none_annotation_handling.py
+++ b/tests/test_none_annotation_handling.py
@@ -1,0 +1,188 @@
+"""
+Tests for handling None annotations in PDF processing.
+
+These tests verify that PyPDFForm can gracefully handle PDFs where
+annot.get_object() returns None (corrupted annotations or missing references).
+This was the cause of the bug:
+    AttributeError: 'NoneType' object has no attribute 'items'
+"""
+
+import warnings
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pypdf import PdfWriter
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    NameObject,
+    NumberObject,
+    TextStringObject,
+)
+
+from PyPDFForm import PdfWrapper
+
+
+def create_pdf_with_text_widget(name: str = "test_field") -> bytes:
+    """Helper to create a simple PDF with a text widget."""
+    writer = PdfWriter()
+    writer.add_blank_page(612, 792)
+
+    widget = DictionaryObject()
+    widget[NameObject("/Type")] = NameObject("/Annot")
+    widget[NameObject("/Subtype")] = NameObject("/Widget")
+    widget[NameObject("/FT")] = NameObject("/Tx")
+    widget[NameObject("/T")] = TextStringObject(name)
+    widget[NameObject("/Rect")] = ArrayObject([
+        NumberObject(100), NumberObject(100),
+        NumberObject(200), NumberObject(120)
+    ])
+
+    writer.pages[0][NameObject("/Annots")] = ArrayObject()
+    writer.pages[0][NameObject("/Annots")].append(writer._add_object(widget))
+
+    pdf_bytes = BytesIO()
+    writer.write(pdf_bytes)
+    pdf_bytes.seek(0)
+    return pdf_bytes.read()
+
+
+class TestTraversePatternNoneHandling:
+    """Tests showing traverse_pattern doesn't handle None - callers must check."""
+
+    def test_traverse_pattern_with_none_raises_attribute_error(self):
+        """
+        traverse_pattern raises AttributeError when widget is None.
+        This documents WHY we need the None checks in the calling code.
+        """
+        from PyPDFForm.utils import traverse_pattern
+
+        with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'items'"):
+            traverse_pattern({"/T": True}, None)
+
+
+class TestNoneAnnotationFix:
+    """
+    Tests that verify the None annotation fix works and emits warnings.
+
+    The fix adds this pattern before calling get_widget_key:
+        annot_obj = annot.get_object()
+        if annot_obj is None:
+            warn(...)
+            continue
+    """
+
+    def test_filler_handles_none_annotation_with_warning(self):
+        """Test filler.py skips None annotations and emits warning."""
+        from PyPDFForm.filler import fill
+
+        pdf_bytes = create_pdf_with_text_widget("test")
+        wrapper = PdfWrapper(pdf_bytes)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            with patch('PyPDFForm.filler.PdfWriter') as MockWriter:
+                mock_writer = MagicMock()
+                MockWriter.return_value = mock_writer
+
+                # Create mock page with one None annotation
+                mock_none_annot = MagicMock()
+                mock_none_annot.get_object.return_value = None
+
+                mock_page = MagicMock()
+                mock_page.get.return_value = [mock_none_annot]
+                mock_writer.pages = [mock_page]
+
+                def mock_write(f):
+                    f.write(pdf_bytes)
+
+                mock_writer.write.side_effect = mock_write
+
+                result, _ = fill(
+                    pdf_bytes,
+                    wrapper.widgets,
+                    need_appearances=False,
+                    use_full_widget_name=False,
+                    flatten=False,
+                )
+
+                assert isinstance(result, bytes)
+
+                # Should have emitted a warning
+                warning_messages = [str(warning.message) for warning in w]
+                assert any("annotation object is None" in msg for msg in warning_messages)
+                assert any("page 1" in msg for msg in warning_messages)
+
+    def test_hooks_handles_none_annotation_with_warning(self):
+        """Test hooks.py skips None annotations and emits warning."""
+        from PyPDFForm.hooks import trigger_widget_hooks
+
+        pdf_bytes = create_pdf_with_text_widget("test")
+        wrapper = PdfWrapper(pdf_bytes)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            with patch('PyPDFForm.hooks.PdfWriter') as MockWriter:
+                mock_writer = MagicMock()
+                MockWriter.return_value = mock_writer
+
+                mock_none_annot = MagicMock()
+                mock_none_annot.get_object.return_value = None
+
+                mock_page = MagicMock()
+                mock_page.get.return_value = [mock_none_annot]
+                mock_writer.pages = [mock_page]
+
+                def mock_write(f):
+                    f.write(pdf_bytes)
+
+                mock_writer.write.side_effect = mock_write
+
+                result = trigger_widget_hooks(pdf_bytes, wrapper.widgets, False)
+                assert isinstance(result, bytes)
+
+                # Should have emitted a warning
+                warning_messages = [str(warning.message) for warning in w]
+                assert any("annotation object is None" in msg for msg in warning_messages)
+
+    def test_update_widget_keys_handles_none_annotation_with_warning(self):
+        """Test template.py update_widget_keys skips None annotations and warns."""
+        from PyPDFForm.template import update_widget_keys
+
+        pdf_bytes = create_pdf_with_text_widget("test")
+        wrapper = PdfWrapper(pdf_bytes)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            with patch('PyPDFForm.template.PdfWriter') as MockWriter:
+                mock_writer = MagicMock()
+                MockWriter.return_value = mock_writer
+
+                mock_none_annot = MagicMock()
+                mock_none_annot.get_object.return_value = None
+
+                mock_page = MagicMock()
+                mock_page.get.return_value = [mock_none_annot]
+                mock_writer.pages = [mock_page]
+
+                def mock_write(f):
+                    f.write(pdf_bytes)
+
+                mock_writer.write.side_effect = mock_write
+
+                result = update_widget_keys(
+                    pdf_bytes,
+                    wrapper.widgets,
+                    ["test"],
+                    ["renamed"],
+                    [0],
+                )
+                assert isinstance(result, bytes)
+
+                # Should have emitted a warning
+                warning_messages = [str(warning.message) for warning in w]
+                assert any("annotation object is None" in msg for msg in warning_messages)


### PR DESCRIPTION
fixes:
```
Traceback (most recent call last):
  File "/pkg/edit/edit_pdf/form_utils.py", line 932, in safe_create_fields
    wrapper = wrapper.bulk_create_fields(fields)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PyPDFForm/wrapper.py", line 499, in bulk_create_fields
    self._bulk_create_fields(each)
  File "/usr/local/lib/python3.11/site-packages/PyPDFForm/wrapper.py", line 540, in _bulk_create_fields
    self._stream = copy_watermark_widgets(
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PyPDFForm/watermark.py", line 251, in copy_watermark_widgets
    key = get_widget_key(annot.get_object(), False)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PyPDFForm/template.py", line 169, in get_widget_key
    return extract_widget_property(widget, WIDGET_KEY_PATTERNS, None, str)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PyPDFForm/utils.py", line 292, in extract_widget_property
    value = traverse_pattern(pattern, widget)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/PyPDFForm/utils.py", line 248, in traverse_pattern
    for key, value in widget.items():
                      ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'items'
```