### PR TITLE
add watermark truncate

### DIFF
--- a/PyPDFForm/widgets/base.py
+++ b/PyPDFForm/widgets/base.py
@@ -235,6 +235,7 @@ class Widget:
                 continue
 
             watermark.seek(0)
+            watermark.truncate(0)
             watermark.flush()
 
             canvas = Canvas(


### PR DESCRIPTION
fix critical bug that caused duplicate field creation

Fix field duplication in bulk_create_fields on multi-page PDFs
Bug: When using bulk_create_fields on multi-page PDFs, widgets from earlier pages would incorrectly appear on later pages. Cause: The BytesIO buffer in bulk_watermarks was reused across pages without being cleared. seek(0) only moves the cursor—it doesn't erase data. When a later page wrote less data than a previous page, leftover bytes remained and got included in the output. Fix: Added truncate(0) after seek(0) to clear the buffer before each page.