### PR TITLE
fix null annotation bug

### DIFF
--- a/PyPDFForm/ap.py
+++ b/PyPDFForm/ap.py
@@ -12,9 +12,36 @@ from io import BytesIO
 
 from pikepdf import Pdf
 from pypdf import PdfReader, PdfWriter
+from pypdf.generic import ArrayObject, NameObject, NullObject
 
 from .constants import XFA, AcroForm, Root
 from .utils import stream_to_io
+
+
+def _remove_null_annotations(reader: PdfReader) -> None:
+    """
+    Remove null objects from annotation arrays in all pages.
+
+    Some malformed PDFs contain NullObject entries in their /Annots arrays,
+    which causes pypdf to fail when merging. This function filters them out.
+
+    Args:
+        reader: The PdfReader to clean up (modified in place).
+    """
+    for page in reader.pages:
+        if "/Annots" in page:
+            annots = page["/Annots"]
+            if annots is not None:
+                # Get the actual array object, resolving indirect references
+                annots_array = annots.get_object() if hasattr(annots, "get_object") else annots
+                if isinstance(annots_array, ArrayObject):
+                    # Filter out NullObject entries
+                    filtered = [
+                        annot for annot in annots_array
+                        if not isinstance(annot.get_object() if hasattr(annot, "get_object") else annot, NullObject)
+                    ]
+                    if len(filtered) != len(annots_array):
+                        page[NameObject("/Annots")] = ArrayObject(filtered)
 
 
 @lru_cache
@@ -45,6 +72,7 @@ def appearance_streams_handler(pdf: bytes, generate_appearance_streams: bool) ->
     if AcroForm in reader.trailer[Root] and XFA in reader.trailer[Root][AcroForm]:
         del reader.trailer[Root][AcroForm][XFA]
 
+    _remove_null_annotations(reader)
     writer.append(reader)
     writer.set_need_appearances_writer()
 

--- a/PyPDFForm/template.py
+++ b/PyPDFForm/template.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Tuple, Union, cast
 from warnings import warn
 
 from pypdf import PdfReader, PdfWriter
-from pypdf.generic import DictionaryObject
+from pypdf.generic import DictionaryObject, NullObject
 
 from .constants import WIDGET_TYPES, Annots, MaxLen, Parent, T
 from .middleware.checkbox import Checkbox
@@ -136,7 +136,10 @@ def get_widgets_by_page(pdf: bytes) -> Dict[int, List[dict]]:
         result[i + 1] = []
         if widgets:
             for widget in widgets:
-                widget = dict(widget.get_object())
+                widget_obj = widget.get_object()
+                if widget_obj is None or isinstance(widget_obj, NullObject):
+                    continue
+                widget = dict(widget_obj)
                 for each in WIDGET_TYPE_PATTERNS:
                     patterns = each[0]
                     check = True

--- a/tests/test_none_annotation_handling.py
+++ b/tests/test_none_annotation_handling.py
@@ -17,6 +17,7 @@ from pypdf.generic import (
     ArrayObject,
     DictionaryObject,
     NameObject,
+    NullObject,
     NumberObject,
     TextStringObject,
 )
@@ -186,3 +187,87 @@ class TestNoneAnnotationFix:
                 # Should have emitted a warning
                 warning_messages = [str(warning.message) for warning in w]
                 assert any("annotation object is None" in msg for msg in warning_messages)
+
+
+class TestNullObjectAnnotationFix:
+    """
+    Tests for handling NullObject annotations in PDF processing.
+
+    Some malformed PDFs contain NullObject entries in their /Annots arrays,
+    which causes pypdf to fail with:
+        TypeError: 'NullObject' object is not subscriptable
+
+    The fix in ap.py filters out these NullObject entries before appending.
+    """
+
+    def test_remove_null_annotations_filters_null_objects(self):
+        """Test that _remove_null_annotations filters out NullObject entries."""
+        from pypdf import PdfReader
+        from PyPDFForm.ap import _remove_null_annotations
+
+        # Create a PDF with a valid widget
+        writer = PdfWriter()
+        writer.add_blank_page(612, 792)
+
+        widget = DictionaryObject()
+        widget[NameObject("/Type")] = NameObject("/Annot")
+        widget[NameObject("/Subtype")] = NameObject("/Widget")
+        widget[NameObject("/FT")] = NameObject("/Tx")
+        widget[NameObject("/T")] = TextStringObject("test_field")
+        widget[NameObject("/Rect")] = ArrayObject([
+            NumberObject(100), NumberObject(100),
+            NumberObject(200), NumberObject(120)
+        ])
+
+        # Add annotations array with a valid widget and a NullObject
+        annots = ArrayObject()
+        annots.append(writer._add_object(widget))
+        annots.append(NullObject())  # This would cause pypdf to fail
+        writer.pages[0][NameObject("/Annots")] = annots
+
+        pdf_bytes = BytesIO()
+        writer.write(pdf_bytes)
+        pdf_bytes.seek(0)
+
+        # Now read it back and apply the fix
+        reader = PdfReader(pdf_bytes)
+
+        # Before fix: should have 2 annotations (1 valid + 1 null)
+        original_annots = reader.pages[0]["/Annots"]
+        assert len(original_annots) == 2
+
+        # Apply the fix
+        _remove_null_annotations(reader)
+
+        # After fix: should have only 1 annotation (null filtered out)
+        filtered_annots = reader.pages[0]["/Annots"]
+        assert len(filtered_annots) == 1
+
+    def test_pdf_with_null_annotation_can_be_processed(self):
+        """Test that a PDF with NullObject annotations can be processed by PdfWrapper."""
+        # Create a PDF with a NullObject in annotations
+        writer = PdfWriter()
+        writer.add_blank_page(612, 792)
+
+        widget = DictionaryObject()
+        widget[NameObject("/Type")] = NameObject("/Annot")
+        widget[NameObject("/Subtype")] = NameObject("/Widget")
+        widget[NameObject("/FT")] = NameObject("/Tx")
+        widget[NameObject("/T")] = TextStringObject("test_field")
+        widget[NameObject("/Rect")] = ArrayObject([
+            NumberObject(100), NumberObject(100),
+            NumberObject(200), NumberObject(120)
+        ])
+
+        annots = ArrayObject()
+        annots.append(writer._add_object(widget))
+        annots.append(NullObject())  # Would cause TypeError without the fix
+        writer.pages[0][NameObject("/Annots")] = annots
+
+        pdf_bytes = BytesIO()
+        writer.write(pdf_bytes)
+        pdf_bytes.seek(0)
+
+        # This should not raise TypeError: 'NullObject' object is not subscriptable
+        wrapper = PdfWrapper(pdf_bytes.read())
+        assert "test_field" in wrapper.widgets


### PR DESCRIPTION
error message:
```
Traceback (most recent call last):
  File "/pkg/process.py", line 503, in process_completed_batches
    edit_response, file_type = await edit_document(
                               ^^^^^^^^^^^^^^^^^^^^
  File "/pkg/edit/__init__.py", line 111, in edit_document
    pdf_result = await edit_pdf_document(download, config, organization, job_id)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/edit/edit_pdf/process_pdf.py", line 92, in edit_pdf_document
    form_processor = FormProcessor(document_path, hex_to_rgb(config.edit_options.color))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/edit/edit_pdf/forms.py", line 109, in __init__
    self.wrapper = PdfWrapper(
                   ^^^^^^^^^^^
  File "/.uv/.venv/lib/python3.11/site-packages/PyPDFForm/wrapper.py", line 120, in __init__
    self._init_helper()
  File "/.uv/.venv/lib/python3.11/site-packages/PyPDFForm/wrapper.py", line 175, in _init_helper
    if self.read()
       ^^^^^^^^^^^
  File "/.uv/.venv/lib/python3.11/site-packages/PyPDFForm/wrapper.py", line 348, in read
    self._stream = appearance_streams_handler(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.uv/.venv/lib/python3.11/site-packages/PyPDFForm/ap.py", line 48, in appearance_streams_handler
    writer.append(reader)
  File "/.uv/.venv/lib/python3.11/site-packages/pypdf/_writer.py", line 2706, in append
    self.merge(
  File "/.uv/.venv/lib/python3.11/site-packages/pypdf/_writer.py", line 2864, in merge
    lst = self._insert_filtered_annotations(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.uv/.venv/lib/python3.11/site-packages/pypdf/_writer.py", line 3038, in _insert_filtered_annotations
    ano["/Subtype"] != "/Link"
    ~~~^^^^^^^^^^^^
TypeError: 'NullObject' object is not subscriptable
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/pypdfform-reducto/pull/8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
